### PR TITLE
Right-arrow key cannot navigate past last character

### DIFF
--- a/app/editor.go
+++ b/app/editor.go
@@ -20,7 +20,7 @@ func (e *lineEditor) Edit(v *gocui.View, key gocui.Key, ch rune, mod gocui.Modif
 	// Disable line wrapping (right arrow key at line end wraps too)
 	case gocui.KeyArrowRight:
 		x, _ := v.Cursor()
-		if x >= len(v.ViewBuffer())-2 {
+		if x >= len(v.ViewBuffer())-1 {
 			return
 		}
 


### PR DESCRIPTION
While editing the domain parts in the editor compartments (Part 1, Part 2, TLDs), I've noticed that the right-arrow key cannot navigate past the last character in those compartments which makes it difficult to impossible to delete the last character (on some keyboards).

This PR allows to navigate past the last character in the editor compartments.